### PR TITLE
Codepipeline container compute memory increased

### DIFF
--- a/cdk/lib/ConverterPipelineStack.ts
+++ b/cdk/lib/ConverterPipelineStack.ts
@@ -43,7 +43,8 @@ export class ConverterPipeLineStack extends cdk.Stack {
       source: projectSource,
       concurrentBuildLimit: 1,
       environment: {
-        buildImage: codebuild.LinuxBuildImage.STANDARD_5_0
+        buildImage: codebuild.LinuxBuildImage.STANDARD_5_0,
+        computeType: codebuild.ComputeType.LARGE
       },
       role,
       buildSpec: codebuild.BuildSpec.fromObject({
@@ -53,7 +54,14 @@ export class ConverterPipeLineStack extends cdk.Stack {
             commands: ['node --version', `aws s3 sync s3://${configBucket}/${appConfigsFolder}/app .`, 'npm install']
           },
           build: {
-            commands: ['npm run build', 'cd cdk', `aws s3 sync s3://${configBucket}/${appConfigsFolder}/cdk .`, 'npm install', 'npm run deploy']
+            commands: [
+              'export NODE_OPTIONS="--max-old-space-size=8192"',
+              'npm run build',
+              'cd cdk',
+              `aws s3 sync s3://${configBucket}/${appConfigsFolder}/cdk .`,
+              'npm install',
+              'npm run deploy'
+            ]
           }
         }
       })
@@ -82,7 +90,6 @@ export class ConverterPipeLineStack extends cdk.Stack {
       ],
       viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS
     });
-
 
     new deploy.BucketDeployment(this, `${environment}-converter-dapp-deployment`, {
       sources: [deploy.Source.asset('../build')],


### PR DESCRIPTION
Codepipeline container compute memory increased since we are using Cardano serialization libraries the react build command is now requires at least 8GB