### PR TITLE
Remove Network listener for Cardano web wallet

### DIFF
--- a/src/libraries/useInjectableWalletHook.js
+++ b/src/libraries/useInjectableWalletHook.js
@@ -144,7 +144,7 @@ const useInjectableWalletHook = (supportingWallets, expectedNetworkId) => {
         throw new Error('Invalid network id selected');
       }
 
-      listenEvents(injectedWallet);
+      // listenEvents(injectedWallet);
 
       return injectedWallet;
     } catch (error) {


### PR DESCRIPTION
Removing Network listener for Cardano web wallet as it is not working with Eternl wallet and we want to test the other functionalities of Eternl wallet